### PR TITLE
Setup SonarCloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,19 @@ language: python
 services:
   - docker
 # The default distribution (ubuntu 14.04) don't support Python 3.7.
-dist: xenial
-python:
-  - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - dist: trusty
+      python: "3.6"
+      script:
+        - make test-coverage
+        - make linters
+        - sonar-scanner
+    - dist: xenial
+      python: "3.7"
+      script: make test
 install:
   - pip install -r requirements_dev.txt
-script: make test && make linters
 notifications:
   email:
     - opensource@system73.com
@@ -24,3 +30,11 @@ deploy:
   on:
     tags: true
     branch: master
+# Allow SonarCloud to access the full SCM history.
+git:
+  depth: false
+addons:
+  sonarcloud:
+    organization: "system73"
+    token:
+      secure: "QJKV4sWic7jeuVgBrLFpCLg215ilpyxPDwef53cNYaZet6htAa26riL0TOgLeKEm4RTqOvAWFR9mYxIyiLh9BHkbiPUKYYyzsJaUqvX3PlqsO/1EPbD1CZ3FVGdP04W7+OM7Q6umchYALgo+A/bz5OdVEVMa4y3wqZCbFautVp4V8KBbrbKP8xvOCQmgM/GETuU6wYyl0EUPzxKba0XxkI9ZHAcIOLEj+Njyy+GumnSwyuI84TYyKR6HDy4wrm6GEIC6hoXqFm+XAV3nYECOsph91M6EycmdwsqIInLz/yS/GBSFpCBzyXTIIUWCLNawK6oSbh0Y67wXLzir5w7dfMuFKxWkutH0jmYbNrpSFK9MYPoCV5YKYRfvsN7spSsPKuq+Lkv4iSxzRGHgJNznA/eosJjNp1ieBzdkLG7Zz32I4kgbZjhJnohmK9jeezof/YC1lki0CSmu0RZ77oZPpEnOU9b0go6cSJlRSFe8OmWAP2T/ycBgfbBRoLf1ZzSfC6qeXMGz4l/uoM5g6lHZdFHbYBCOhWqcRSFbwRZzFdO6LyIoykF44s+Npkdnv7bGnWek+V+h2O8pdfgltnd72MAJUTsyHZyDST+sUuwdWTtO0YsSq9+J4h+ddPQ3rR2z3S/L/YzVHVOoB7BuC3IRBzVPjDUoJZRwstInmYmsqyo="

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,8 @@
 aio-etcd==0.4.6.1
 aiohttp==3.5.4
 aiohttp-cors==0.7.0
+attrs>=17.4
+black==19.3b0
 bumpversion==0.5.3
 cachetools==3.1.0
 cookiecutter==1.6.0
@@ -39,4 +41,3 @@ ujson==1.35
 urllib3==1.25.2
 watchdog==0.9.0
 wheel==0.33.4
-black==19.3b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 0.1.0
-commit = True
+commit = False
 tag = False
 
 [bumpversion:file:setup.py]
@@ -14,6 +14,10 @@ replace = __version__ = '{new_version}'
 [bumpversion:file:docs/conf.py]
 search = version = '{current_version}'
 replace = version = '{new_version}'
+
+[bumpversion:file:sonar-project.properties]
+search = sonar.projectVersion={current_version}
+replace = sonar.projectVersion={new_version}
 
 [bdist_wheel]
 universal = 1

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,6 @@
-sonar.projectKey=tamarco
-sonar.sources=./tamarco
-sonar.projectName=Tamarco
-sonar.python.coverage.reportPath=./reports/coverage.xml
+sonar.projectKey=System73_tamarco
+sonar.sources=tamarco
+sonar.exclusions=tamarco/tools/project/project_template/**/*
+sonar.projectName=tamarco
+sonar.projectVersion=0.1.0
+sonar.python.coverage.reportPaths=./reports/coverage.xml


### PR DESCRIPTION
* Configured SonarCloud.
* Configured Bumpversion to modify the package version of the `sonar-project.properties` file.
* Added execution matrix in Travis, the SonarCloud is only launched with Trusty distribution. We use Xenial distribution to launch Pyhon3.7.