### PR TITLE
Handle possible error reading own_ip

### DIFF
--- a/tamarco/resources/basic/registry/resource.py
+++ b/tamarco/resources/basic/registry/resource.py
@@ -23,8 +23,15 @@ class Registry(BaseResource, metaclass=Singleton):
         self.etcd_client = None
         self.register_task = None
         self.logger = logging.getLogger("tamarco.registry")
-        self.own_ip = socket.gethostbyname(socket.gethostname())
+        self.own_ip = self._get_own_ip()
         super().__init__(*args, **kwargs)
+
+    def _get_own_ip(self):
+        try:
+            return socket.gethostbyname(socket.gethostname())
+        except Exception:
+            self.logger.exception("Could not determine the IP to expose in the registry resource")
+            return "Unknown"
 
     async def post_start(self):
         enabled_setting = await self.settings.get("enabled", False)


### PR DESCRIPTION
In my personal computer, I get the following error starting a tamarco microservice, preventing the framework from working:

`Traceback (most recent call last):
  File "examples/http_resource/microservice.py", line 7, in <module>
    from tamarco.core.microservice import Microservice, MicroserviceContext, thread
  File "/Users/mordis/WorkSpace/GitHub/tamarco/virtualenv/lib/python3.7/site-packages/tamarco/core/microservice.py", line 202, in <module>
    class Microservice(MicroserviceBase):
  File "/Users/mordis/WorkSpace/GitHub/tamarco/virtualenv/lib/python3.7/site-packages/tamarco/core/microservice.py", line 230, in Microservice
    registry = Registry()
  File "/Users/mordis/WorkSpace/GitHub/tamarco/virtualenv/lib/python3.7/site-packages/tamarco/core/patterns/singleton.py", line 20, in __call__
    cls._instances[cls] = super().__call__(*args, **kwargs)
  File "/Users/mordis/WorkSpace/GitHub/tamarco/virtualenv/lib/python3.7/site-packages/tamarco/resources/basic/registry/resource.py", line 26, in __init__
    self.own_ip = socket.gethostbyname(socket.gethostname())
socket.gaierror: [Errno 8] nodename nor servname provided, or not known`

The code handles the possible error and allows the microservice to start.